### PR TITLE
Update tiny_gameplay_controller.py

### DIFF
--- a/tiny_gameplay_controller.py
+++ b/tiny_gameplay_controller.py
@@ -2037,7 +2037,22 @@ class GameplayController:
                     current_value = getattr(character, skill, 0)
                     # Small skill improvement with diminishing returns
                     improvement = max(1, int(5 * (100 - current_value) / 100))
-                    setattr(character, skill, min(100, current_value + improvement))
+                    if improvement > 0: # Only proceed if there's an actual improvement calculated
+                        setattr(character, skill, min(100, current_value + improvement))
+                        new_skill_value = getattr(character, skill)
+
+                        if skill == "job_performance" and new_skill_value > old_skill_value:
+                            if hasattr(character, 'current_satisfaction'):
+                                satisfaction_bonus = 2
+                                character.current_satisfaction += satisfaction_bonus
+                                character.current_satisfaction = min(100, character.current_satisfaction)
+                                logger.debug(
+                                    f"{character.name} feels more satisfied from improving job performance! "
+                                    f"Satisfaction +{satisfaction_bonus} (now {character.current_satisfaction})."
+                                )
+                    else: # If improvement is 0, skill remains unchanged.
+                        pass
+
 
         except Exception as e:
             logger.warning(f"Error updating character skills: {e}")


### PR DESCRIPTION
feat: Add satisfaction bonus for job performance increase

This commit enhances the character skill system by linking improvements in 'job_performance' to a character's satisfaction.

- When a character's `job_performance` skill increases as a result of performing actions like 'work', 'craft', or 'cook', they now receive a +2 bonus to their `current_satisfaction`.
- The `current_satisfaction` is capped at a maximum of 100.
- A debug log message is now generated when this satisfaction bonus