### PR TITLE
Fix: Correct speed text caching and clarify achievements init

### DIFF
--- a/test_tiny_gameplay_controller.py
+++ b/test_tiny_gameplay_controller.py
@@ -1,0 +1,145 @@
+import unittest
+import pygame # Pygame will be needed for font rendering and potentially other UI elements.
+from tiny_gameplay_controller import GameplayController, MIN_SPEED, MAX_SPEED, SPEED_STEP # Import constants too
+
+# Minimal mock for GraphManager if needed by GameplayController constructor
+class MockGraphManager:
+    pass
+
+class TestGameplayController(unittest.TestCase):
+
+    def setUp(self):
+        # Basic Pygame setup needed for font rendering.
+        # This avoids full game initialization if possible.
+        pygame.init()
+        # It's good practice to set a display mode, even if it's small and not shown,
+        # as some Pygame modules (like font) might depend on it.
+        try:
+            pygame.display.set_mode((1, 1))
+        except pygame.error as e:
+            print(f"Skipping display.set_mode in test setup (possibly headless environment): {e}")
+
+
+        # Mock GraphManager if GameplayController requires it.
+        # Adjust based on actual GameplayController constructor requirements.
+        self.mock_graph_manager = MockGraphManager()
+        # Provide a minimal config if necessary
+        self.config = {
+            "screen_width": 800,
+            "screen_height": 600,
+            "map": {
+                "image_path": "assets/default_map.png", # Dummy path, map won't be loaded
+                "width": 100,
+                "height": 100,
+                "buildings_file": None
+            },
+             "characters": {
+                "count": 0 # Avoid character creation for these tests
+            },
+            "key_bindings": { # Add if controller accesses this during init for speed keys
+                "increase_speed": [pygame.K_PAGEUP],
+                "decrease_speed": [pygame.K_PAGEDOWN],
+            }
+        }
+        self.controller = GameplayController(graph_manager=self.mock_graph_manager, config=self.config)
+        # Ensure a screen is available for rendering, even if it's a dummy one for tests.
+        if not self.controller.screen:
+            self.controller.screen = pygame.Surface((self.config["screen_width"], self.config["screen_height"]))
+
+
+    def tearDown(self):
+        pygame.quit()
+
+    def test_global_achievements_initialization(self):
+        """Test that global_achievements is initialized correctly."""
+        self.assertIsNotNone(self.controller.global_achievements)
+        self.assertIsInstance(self.controller.global_achievements, dict)
+        self.assertIn("village_milestones", self.controller.global_achievements)
+        self.assertIn("social_achievements", self.controller.global_achievements)
+        self.assertIn("economic_achievements", self.controller.global_achievements)
+        self.assertIsInstance(self.controller.global_achievements["village_milestones"], dict)
+
+    def test_speed_text_caching(self):
+        """Test the caching mechanism for the speed text UI element."""
+        # Initial render
+        self.controller._render_ui() # Call private method for testing specific UI part
+        initial_cached_surface = self.controller._cached_speed_text
+        self.assertIsNotNone(initial_cached_surface, "Speed text should be cached on first render.")
+
+        # Call render_ui again without changing time_scale_factor
+        self.controller._render_ui()
+        second_cached_surface = self.controller._cached_speed_text
+        self.assertIs(initial_cached_surface, second_cached_surface,
+                        "Cached surface should be the same object if time_scale_factor is unchanged.")
+
+        # Change time_scale_factor (ensure it's a different value)
+        original_speed = self.controller.time_scale_factor
+        new_speed = original_speed + SPEED_STEP
+        if new_speed > MAX_SPEED: # ensure new_speed is valid and different
+            new_speed = original_speed - SPEED_STEP
+            if new_speed < MIN_SPEED: # if original was MAX_SPEED
+                 new_speed = MIN_SPEED if MAX_SPEED == MIN_SPEED else (MIN_SPEED + MAX_SPEED) / 2
+
+
+        self.controller.time_scale_factor = new_speed
+        # Manually invalidate cache as _handle_keydown would do, or rely on _render_ui's check
+        # In this specific test, we want to check the _render_ui internal caching logic,
+        # so we don't invalidate it here. The next test checks _handle_keydown's invalidation.
+        # self.controller._cached_speed_text = None
+
+        self.controller._render_ui()
+        third_cached_surface = self.controller._cached_speed_text
+        self.assertIsNotNone(third_cached_surface, "Speed text should be re-rendered and cached.")
+        self.assertIsNot(initial_cached_surface, third_cached_surface,
+                         "Cached surface should be a new object if time_scale_factor changed.")
+
+        # Test that setting the speed to the same value (after it was changed) still uses cache if not invalidated
+        # This requires _last_time_scale_factor to be correctly updated
+        self.controller.time_scale_factor = new_speed # Set to same new_speed
+        self.controller._render_ui() # Render with new_speed (should use cache from previous render at new_speed)
+        fourth_cached_surface = self.controller._cached_speed_text
+        self.assertIs(third_cached_surface, fourth_cached_surface,
+                        "Cached surface should remain the same if time_scale_factor is set to the same value it was just changed to.")
+
+
+    def test_speed_text_cache_invalidation_via_handle_keydown(self):
+        """Test that cache is invalidated when speed changes via _handle_keydown."""
+        # Initial render and cache
+        self.controller._render_ui()
+        initial_cached_surface = self.controller._cached_speed_text
+        self.assertIsNotNone(initial_cached_surface)
+
+        # Simulate key press to increase speed
+        # Need to find the actual key, not just the string 'increase_speed'
+        increase_key = self.controller.config.get("key_bindings", {}).get("increase_speed", [pygame.K_PAGEUP])[0]
+        mock_event_increase = pygame.event.Event(pygame.KEYDOWN, key=increase_key)
+
+        original_speed = self.controller.time_scale_factor
+        self.controller._handle_keydown(mock_event_increase) # This should invalidate the cache (_cached_speed_text = None)
+
+        # Speed must have changed for cache to be different
+        self.assertNotEqual(original_speed, self.controller.time_scale_factor, "Speed should change on key press.")
+
+        self.controller._render_ui() # This should re-render due to invalidated cache
+        new_cached_surface_increase = self.controller._cached_speed_text
+        self.assertIsNotNone(new_cached_surface_increase)
+        self.assertIsNot(initial_cached_surface, new_cached_surface_increase,
+                         "Cache should be different after speed increase.")
+
+        # Simulate key press to decrease speed
+        decrease_key = self.controller.config.get("key_bindings", {}).get("decrease_speed", [pygame.K_PAGEDOWN])[0]
+        mock_event_decrease = pygame.event.Event(pygame.KEYDOWN, key=decrease_key)
+
+        current_speed_before_decrease = self.controller.time_scale_factor
+        self.controller._handle_keydown(mock_event_decrease)
+
+        self.assertNotEqual(current_speed_before_decrease, self.controller.time_scale_factor, "Speed should change on key press for decrease.")
+
+        self.controller._render_ui()
+        new_cached_surface_decrease = self.controller._cached_speed_text
+        self.assertIsNotNone(new_cached_surface_decrease)
+        self.assertIsNot(new_cached_surface_increase, new_cached_surface_decrease,
+                         "Cache should be different after speed decrease.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tiny_gameplay_controller.py
+++ b/tiny_gameplay_controller.py
@@ -1413,7 +1413,6 @@ class GameplayController:
             self._show_analytics_info()
         elif event.key in key_bindings.get("increase_speed", []):
             self.time_scale_factor = min(MAX_SPEED, self.time_scale_factor + SPEED_STEP)
-            self.time_scale_factor = min(MAX_SPEED, self.time_scale_factor + SPEED_STEP)
             logger.info(f"Time scale set to: {self.time_scale_factor:.1f}x")
             self._cached_speed_text = None # Invalidate cache on change
 

--- a/tiny_gameplay_controller.py
+++ b/tiny_gameplay_controller.py
@@ -5,6 +5,12 @@ import traceback
 import json
 import os
 import datetime # Added for time-based achievement
+
+# Constants for speed control
+MAX_SPEED = 5.0
+MIN_SPEED = 0.1
+SPEED_STEP = 0.1
+
 WEATHER_ENERGY_EFFECTS = {
     'rainy': 0.5,
     # 'snowy': 1.0, # easy to add more
@@ -557,6 +563,8 @@ class GameplayController:
             "characters_created": 0,
             "errors_recovered": 0,
         }
+        # Instance-level dictionary to track achievements for this game session.
+        # Initialized here during the instantiation of GameplayController.
         self.global_achievements = {
             "village_milestones": {
                 "first_character_created": False,
@@ -1405,10 +1413,15 @@ class GameplayController:
             self._show_analytics_info()
         elif event.key in key_bindings.get("increase_speed", []):
             self.time_scale_factor = min(MAX_SPEED, self.time_scale_factor + SPEED_STEP)
-            logger.info(f"Time scale set to: {self.time_scale_factor}x")
-        elif event.key in key_bindings.get("decrease_speed", []):
+            self.time_scale_factor = min(MAX_SPEED, self.time_scale_factor + SPEED_STEP)
+            logger.info(f"Time scale set to: {self.time_scale_factor:.1f}x")
+            self._cached_speed_text = None # Invalidate cache on change
+
+        # For decreasing speed
+        elif event.key in key_bindings.get("decrease_speed", []): # Ensure this key binding exists or add it
             self.time_scale_factor = max(MIN_SPEED, self.time_scale_factor - SPEED_STEP)
-            logger.info(f"Time scale set to: {self.time_scale_factor}x")
+            logger.info(f"Time scale set to: {self.time_scale_factor:.1f}x")
+            self._cached_speed_text = None # Invalidate cache on change
 
     def _show_help_info(self):
         """Display help information."""
@@ -2029,7 +2042,7 @@ class GameplayController:
             self._track_state_changes(character, action, initial_state, final_state)
             # Increment work_action_count if it was a work action
             if hasattr(action, 'name') and 'work' in action.name.lower():
-                if hasattr(character, 'work_action_count'):Add commentMore actions
+                if hasattr(character, 'work_action_count'):
                     character.work_action_count += 1
                     logger.debug(f"{character.name} completed a work action. Total work actions: {character.work_action_count}")
 

--- a/tiny_memories.py
+++ b/tiny_memories.py
@@ -89,7 +89,7 @@ call_flow_diagram = nx.DiGraph()
 from nltk.stem import PorterStemmer
 
 print(
-    f"{os.environ["HF_HOME"]} is set to {os.environ.get('HF_HOME', '/tmp/hf_test_cache')}"
+    f"{os.environ['HF_HOME']} is set to {os.environ.get('HF_HOME', '/tmp/hf_test_cache')}"
 )
 # Set up cache directory
 cache_dir = os.path.join(tempfile.gettempdir(), "hf_test_cache")


### PR DESCRIPTION
This commit addresses several issues:

- Fixes UI speed text caching (Issues #242, #238):
    - Ensures `_last_time_scale_factor` is correctly updated in `_render_ui`.
    - Invalidates `_cached_speed_text` in `_handle_keydown` when speed changes.
    - Adds `MIN_SPEED`, `MAX_SPEED`, and `SPEED_STEP` constants for robust time scale control in `tiny_gameplay_controller.py`.

- Clarifies global_achievements initialization (Issue #234):
    - Adds a comment to `tiny_gameplay_controller.py` to confirm that `global_achievements` is an instance-level variable, initialized during instantiation.

- Adds unit tests:
    - Introduces `test_tiny_gameplay_controller.py`.
    - Includes tests for `global_achievements` initialization.
    - Includes tests for speed text caching logic in `_render_ui` and cache invalidation via `_handle_keydown`.

- Minor syntax error fixes:
    - Corrects an extraneous string in `tiny_gameplay_controller.py`.
    - Fixes incorrect quote usage in an f-string in `tiny_memories.py`.