### PR TITLE
Remove unused imports

### DIFF
--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -1,6 +1,3 @@
-from calendar import c
-from numpy import char
-from requests import get
 import random
 import tiny_characters as tc
 


### PR DESCRIPTION
## Description
Removed unnecessary imports from `tiny_prompt_builder.py` that pulled in calendar, numpy, and requests modules.

## Technical Implementation
- Deleted unused imports: `c` from `calendar`, `char` from `numpy`, and `get` from `requests`.
- Preserved imports for `random` and `tiny_characters`.

## Related Issues
None

## Testing
- `python -m unittest discover tests` *(fails: start directory is not importable)*

## Performance Considerations
- Eliminates unneeded dependencies in this file.

------
https://chatgpt.com/codex/tasks/task_e_6856075ab0588327bd2991b8a7e1c68a