### PR TITLE
Fix friendship grid access in prioritize_actions

### DIFF
--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -342,7 +342,7 @@ class ActionOptions:
             or character.get_community() < 5,
             "pursue_hobby": character.get_happiness() < 5 or character.get_beauty() < 5,
             "self_care": character.get_mental_health() < 5,
-            "social_visit": character["friendship_grid"] < 5,
+            "social_visit": character.get_friendship_grid() < 5,
             "volunteer_time": character.get_community() < 5,
             "improve_job_performance": character.get_job_performance() < 5,
             "get_educated": character.get_long_term_goal() == "career_advancement",


### PR DESCRIPTION
## Description
Replaced direct dictionary access within `ActionOptions.prioritize_actions` with the appropriate accessor method on `Character`.

## Technical Implementation
- Updated friendship grid check to use `character.get_friendship_grid()`.
- Verified there were no other direct attribute accesses in the method.

## Related Issues
Closes #0

## Testing
- `python -m unittest discover tests` *(fails: Start directory is not importable)*

## Performance Considerations
- None

------
https://chatgpt.com/codex/tasks/task_e_685726a1e530832780402615a621a54a