### PR TITLE
Add crisis response prompt with optional utility hint

### DIFF
--- a/test_crisis_prompt.py
+++ b/test_crisis_prompt.py
@@ -1,0 +1,37 @@
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+# Create stub modules to satisfy imports in tiny_prompt_builder
+stub_tc = ModuleType('tiny_characters')
+stub_tc.Character = object
+stub_attr = ModuleType('attr')
+
+class MockCharacter:
+    def __init__(self):
+        self.name = "Eve"
+        self.job = "Farmer"
+        self.recent_event = "outbreak"
+        self.wealth_money = 10
+        self.health_status = 7
+        self.hunger_level = 5
+        self.energy = 5
+        self.mental_health = 6
+        self.social_wellbeing = 6
+
+class CrisisPromptTests(unittest.TestCase):
+    def test_prompt_contains_description_and_assistant_cue(self):
+        with patch.dict(sys.modules, {"tiny_characters": stub_tc, "attr": stub_attr}):
+            import tiny_prompt_builder
+            tiny_prompt_builder.descriptors.event_recent.setdefault("default", [""])
+            tiny_prompt_builder.descriptors.financial_situation.setdefault("default", [""])
+            PromptBuilder = tiny_prompt_builder.PromptBuilder
+            char = MockCharacter()
+            builder = PromptBuilder(char)
+            prompt = builder.generate_crisis_response_prompt("barn fire", urgency="high")
+        self.assertIn("barn fire", prompt)
+        self.assertTrue(prompt.strip().endswith("<|assistant|>"))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -1809,9 +1809,13 @@ class PromptBuilder:
                     best_action = breakdown[0].get("action")
                     if best_action:
                         prompt += f" Recommended immediate action: {best_action}."
-        except Exception:
+        except ImportError:
             # Utility evaluation is optional and may not work if dependencies are missing
             pass
+        except Exception as e:
+            # Log unexpected exceptions for debugging purposes
+            import logging
+            logging.error(f"An unexpected error occurred during utility evaluation: {e}")
 
         prompt += "<|assistant|>"
         return prompt


### PR DESCRIPTION
## Description
Implemented a real version of `generate_crisis_response_prompt` and added a unit test.

## Technical Implementation
- Expanded the crisis prompt generator to accept `crisis_description` and `urgency` parameters.
- Utilized descriptor methods to incorporate context information.
- Optionally evaluates the best action using `UtilityEvaluator.evaluate_plan_utility_advanced` when dependencies are available.
- Added `test_crisis_prompt.py` which validates that the crisis description is present and the prompt ends with the assistant cue.

## Related Issues
Closes #15

## Testing
- `python -m unittest test_crisis_prompt.py -v`
- `python -m unittest` *(fails: missing optional dependencies)*

## Performance Considerations
- No significant impact; optional evaluation executed only if supporting modules load successfully.


------
https://chatgpt.com/codex/tasks/task_e_6857886727088327853809d1127f9a09