### PR TITLE
Integrate strategy actions into prompt builder

### DIFF
--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -1594,8 +1594,9 @@ class PromptBuilder:
         for i, action in enumerate(actions[:5]):
             try:
                 util = calculate_action_utility(char_state, action, current_goal)
-            except Exception:
+            except (ValueError, TypeError):  # Replace with specific exceptions
                 util = 0.0
+                print(f"Error calculating utility for action {action}: {e}")  # Optional logging
 
             effects_str = ""
             if hasattr(action, "effects") and action.effects:

--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -1574,7 +1574,7 @@ class PromptBuilder:
         try:
             from tiny_strategy_manager import StrategyManager
             from tiny_utility_functions import calculate_action_utility
-        except Exception:  # pragma: no cover - gracefully handle missing deps
+        except ImportError:  # pragma: no cover - gracefully handle missing deps
             self.prioritized_actions = []
             self.action_choices = []
             return []


### PR DESCRIPTION
## Description
- retrieve candidate actions from `StrategyManager`
- build action choice strings with utilities
- test dynamic inclusion of generated actions

## Technical Implementation
- call `StrategyManager.get_daily_actions` inside `PromptBuilder.prioritize_actions`
- compute utilities with `calculate_action_utility`
- construct action description strings including effects
- patch prompt tests to stub manager and verify generated actions

## Related Issues
Closes #0

## Testing
- `python -m unittest test_enhanced_decision_prompt.TestEnhancedDecisionPrompt.test_dynamic_action_choices_included -v`
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'torch', etc.)*

## Performance Considerations
- limited to top five actions when constructing prompt

------
https://chatgpt.com/codex/tasks/task_e_687b0a9b067483278171a2e911295ddd