### PR TITLE
Improve PromptBuilder with extra state

### DIFF
--- a/test_enhanced_decision_prompt.py
+++ b/test_enhanced_decision_prompt.py
@@ -419,10 +419,12 @@ class TestEnhancedDecisionPrompt(unittest.TestCase):
             character_state_dict=character_state,
         )
 
-        # The prompt should generate successfully regardless of the character_state_dict
-        # (The current implementation may not use this parameter yet, but it should not break)
         self.assertIsNotNone(prompt)
         self.assertIn("Sarah Chen", prompt)
+        for key, value in character_state.items():
+            formatted_key = key.replace("_", " ").title()
+            expected_line = f"- {formatted_key}: {value}"
+            self.assertIn(expected_line, prompt)
 
         logger.info("Character state dict parameter test completed!")
 

--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -1731,11 +1731,13 @@ class PromptBuilder:
             prompt += f"Your long-term aspiration is: {self.character.long_term_goal}. "
 
         # Include any additional character state provided
-        if character_state_dict:
+        if isinstance(character_state_dict, dict):
             prompt += "\nAdditional state:\n"
             for key, value in character_state_dict.items():
                 formatted_key = key.replace("_", " ").title()
                 prompt += f"- {formatted_key}: {value}\n"
+        elif character_state_dict is not None:
+            raise TypeError("character_state_dict must be a dictionary.")
 
         prompt += f"\n{descriptors.get_routine_question_framing()}"
 

--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -1730,6 +1730,13 @@ class PromptBuilder:
         if hasattr(self.character, "long_term_goal") and self.character.long_term_goal:
             prompt += f"Your long-term aspiration is: {self.character.long_term_goal}. "
 
+        # Include any additional character state provided
+        if character_state_dict:
+            prompt += "\nAdditional state:\n"
+            for key, value in character_state_dict.items():
+                formatted_key = key.replace("_", " ").title()
+                prompt += f"- {formatted_key}: {value}\n"
+
         prompt += f"\n{descriptors.get_routine_question_framing()}"
 
         # Enhanced action choices with better formatting


### PR DESCRIPTION
## Description
- support optional state key-value pairs in `generate_decision_prompt`
- verify that additional state lines appear in prompts

## Technical Implementation
- inject new lines into the user section when `character_state_dict` is provided
- extend the related unit test to check for formatted output

## Related Issues
Closes #

## Testing
- `python -m unittest discover tests` *(fails: ImportError: Start directory is not importable)*
- `python -m unittest discover` *(fails: ModuleNotFoundError for heavy deps)*

------
https://chatgpt.com/codex/tasks/task_e_687b0aa69b6483279afe7ea6615db788