### PR TITLE
Add memory support to decision prompts

### DIFF
--- a/test_decision_prompt_memories.py
+++ b/test_decision_prompt_memories.py
@@ -1,0 +1,55 @@
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import patch
+
+# Stub modules to satisfy imports in tiny_prompt_builder
+stub_tc = ModuleType('tiny_characters')
+stub_tc.Character = object
+stub_attr = ModuleType('attr')
+
+class MockMemory:
+    def __init__(self, description):
+        self.description = description
+
+class MockCharacter:
+    def __init__(self):
+        self.name = "Eve"
+        self.job = "Farmer"
+        self.recent_event = "harvest"
+        self.wealth_money = 5
+        self.health_status = 7
+        self.hunger_level = 4
+        self.energy = 6
+        self.mental_health = 6
+        self.social_wellbeing = 5
+        self.long_term_goal = "grow the best crops"
+        self.motives = None
+
+    def evaluate_goals(self):
+        return []
+
+class DecisionPromptMemoryTests(unittest.TestCase):
+    def test_memories_in_prompt(self):
+        with patch.dict(sys.modules, {"tiny_characters": stub_tc, "attr": stub_attr}):
+            import tiny_prompt_builder
+            # ensure descriptor dictionaries have defaults to avoid KeyError
+            tiny_prompt_builder.descriptors.event_recent.setdefault("default", [""])
+            tiny_prompt_builder.descriptors.financial_situation.setdefault("default", [""])
+            PromptBuilder = tiny_prompt_builder.PromptBuilder
+
+            char = MockCharacter()
+            builder = PromptBuilder(char)
+            memories = [MockMemory("won a pie contest"), MockMemory("lost keys at market")]
+            prompt = builder.generate_decision_prompt(
+                time="noon",
+                weather="sunny",
+                action_choices=["1. Eat lunch"],
+                memories=memories,
+            )
+
+        self.assertIn("won a pie contest", prompt)
+        self.assertIn("lost keys at market", prompt)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_llm_integration_isolated.py
+++ b/test_llm_integration_isolated.py
@@ -51,7 +51,14 @@ class MockPromptBuilder:
     def __init__(self, character=None):
         self.character = character
 
-    def generate_decision_prompt(self, time, weather, action_choices):
+    def generate_decision_prompt(
+        self,
+        time,
+        weather,
+        action_choices,
+        character_state_dict=None,
+        memories=None,
+    ):
         """Generate a mock prompt"""
         choices_text = "\n".join(action_choices)
         return f"""Character {self.character.name if self.character else 'Unknown'} needs to make a decision.

--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -1665,6 +1665,7 @@ class PromptBuilder:
         weather: str,
         action_choices: List[str],
         character_state_dict: Optional[Dict[str, float]] = None,
+        memories: Optional[List] = None,
     ) -> str:
         """Create a decision prompt incorporating goals, needs and context."""
         # Calculate needs priorities for character context
@@ -1729,6 +1730,13 @@ class PromptBuilder:
         # Long-term aspiration context
         if hasattr(self.character, "long_term_goal") and self.character.long_term_goal:
             prompt += f"Your long-term aspiration is: {self.character.long_term_goal}. "
+
+        # Include short memory descriptions if provided
+        if memories:
+            prompt += "\nRecent memories influencing you:\n"
+            for mem in memories[:2]:
+                desc = getattr(mem, "description", str(mem))
+                prompt += f"- {desc}\n"
 
         prompt += f"\n{descriptors.get_routine_question_framing()}"
 


### PR DESCRIPTION
## Description
Adds ability to supply character memories to the decision prompt generator. When provided, the first two memory descriptions are embedded in the prompt. Tests updated and a new test added for memory injection.

## Technical Implementation
- Extended `PromptBuilder.generate_decision_prompt` with `memories` optional argument and injected memory text when available.
- Updated isolated integration test's `MockPromptBuilder` to accept new parameters.
- Created `test_decision_prompt_memories.py` to verify memory text inclusion via mocked memory retrieval.

## Related Issues
Closes #0

## Testing
- `python -m unittest discover tests` *(fails: Start directory is not importable)*

## Performance Considerations
- Minimal impact; simply appends a few strings if memories are provided.

------
https://chatgpt.com/codex/tasks/task_e_687b0aaa51208327b9e95e8ab65431dd