### PR TITLE
Use prioritized actions in daily routine prompt

### DIFF
--- a/tests/test_enhanced_prompt_builder.py
+++ b/tests/test_enhanced_prompt_builder.py
@@ -296,6 +296,156 @@ class TestEnhancedPromptBuilder(unittest.TestCase):
         # Should use legacy memories when memory integration is disabled
         self.prompt_builder.format_memories_for_prompt.assert_called_with(legacy_memories)
 
+    @patch('tiny_prompt_builder.descriptors', mock_descriptors)
+    def test_generate_daily_routine_prompt_with_actions_parameter_none(self):
+        """Test that generate_daily_routine_prompt uses prioritized actions when actions parameter is None."""
+        mock_context = {
+            'character': {
+                'basic_info': {
+                    'name': 'TestCharacter',
+                    'job': 'Engineer'
+                }
+            },
+            'memories': []
+        }
+        
+        self.prompt_builder.context_manager.assemble_complete_context = MagicMock(
+            return_value=mock_context
+        )
+        
+        # Mock ActionOptions.prioritize_actions to return a specific list
+        mock_actions = ['work', 'eat', 'sleep', 'socialize', 'exercise']
+        
+        with patch('tiny_prompt_builder.ActionOptions') as MockActionOptions:
+            mock_instance = MagicMock()
+            mock_instance.prioritize_actions.return_value = mock_actions
+            MockActionOptions.return_value = mock_instance
+            
+            prompt = self.prompt_builder.generate_daily_routine_prompt(
+                "morning", "sunny", actions=None
+            )
+            
+            # Verify that ActionOptions was instantiated and prioritize_actions was called with the character
+            MockActionOptions.assert_called_once()
+            mock_instance.prioritize_actions.assert_called_once_with(self.character)
+        
+        # Verify that actions appear numbered in the prompt (1. 2. 3. etc.)
+        self.assertIn("1.", prompt)
+        self.assertIn("2.", prompt)
+        
+    @patch('tiny_prompt_builder.descriptors', mock_descriptors)
+    def test_generate_daily_routine_prompt_with_actions_parameter_provided(self):
+        """Test that generate_daily_routine_prompt uses provided actions when actions parameter is supplied."""
+        mock_context = {
+            'character': {
+                'basic_info': {
+                    'name': 'TestCharacter',
+                    'job': 'Engineer'
+                }
+            },
+            'memories': []
+        }
+        
+        self.prompt_builder.context_manager.assemble_complete_context = MagicMock(
+            return_value=mock_context
+        )
+        
+        # Patch ActionOptions to verify it's NOT instantiated when actions are provided
+        with patch('tiny_prompt_builder.ActionOptions') as MockActionOptions:
+            # Provide explicit action list
+            custom_actions = ['read_book', 'write_code', 'debug']
+            prompt = self.prompt_builder.generate_daily_routine_prompt(
+                "morning", "sunny", actions=custom_actions
+            )
+            
+            # Verify that ActionOptions was NOT instantiated when actions are provided
+            MockActionOptions.assert_not_called()
+        
+        # Verify that custom actions appear in the prompt
+        self.assertIn("Options:", prompt)
+        
+    @patch('tiny_prompt_builder.descriptors', mock_descriptors)
+    def test_generate_daily_routine_prompt_action_formatting(self):
+        """Test that actions are formatted correctly with numbering during iteration."""
+        mock_context = {
+            'character': {
+                'basic_info': {
+                    'name': 'TestCharacter',
+                    'job': 'Engineer'
+                }
+            },
+            'memories': []
+        }
+        
+        self.prompt_builder.context_manager.assemble_complete_context = MagicMock(
+            return_value=mock_context
+        )
+        
+        # Provide unnumbered actions (as expected by the API)
+        unnumbered_actions = ['action_one', 'action_two', 'action_three']
+        
+        # Mock the descriptor function to avoid KeyError
+        mock_descriptors.get_action_descriptors.side_effect = lambda x: x.replace('_', ' ').title()
+        
+        prompt = self.prompt_builder.generate_daily_routine_prompt(
+            "morning", "sunny", actions=unnumbered_actions
+        )
+        
+        # Verify numbering is added during iteration (not pre-numbered)
+        # Actions should appear as "1. Action One to Action_One."
+        self.assertIn("1. Action One", prompt)
+        self.assertIn("2. Action Two", prompt)
+        self.assertIn("3. Action Three", prompt)
+        
+    @patch('tiny_prompt_builder.descriptors', mock_descriptors)
+    def test_generate_daily_routine_prompt_consistency_with_decision_prompt(self):
+        """Test that generate_daily_routine_prompt and generate_decision_prompt handle actions consistently."""
+        mock_context = {
+            'character': {
+                'basic_info': {
+                    'name': 'TestCharacter',
+                    'job': 'Engineer'
+                }
+            },
+            'memories': [],
+            'goals': {
+                'active_goals': [],
+                'needs_priorities': {}
+            }
+        }
+        
+        self.prompt_builder.context_manager.assemble_complete_context = MagicMock(
+            return_value=mock_context
+        )
+        
+        # Use unnumbered actions for daily_routine (it adds numbering)
+        test_actions = ['work', 'eat', 'sleep']
+        
+        # Mock descriptor to avoid KeyError
+        mock_descriptors.get_action_descriptors.side_effect = lambda x: x.replace('_', ' ').title()
+        
+        # Generate daily routine prompt with unnumbered actions
+        routine_prompt = self.prompt_builder.generate_daily_routine_prompt(
+            "morning", "sunny", actions=test_actions
+        )
+        
+        # Use pre-numbered actions for decision prompt (as used by StrategyManager)
+        pre_numbered_actions = ['1. Work', '2. Eat', '3. Sleep']
+        decision_prompt = self.prompt_builder.generate_decision_prompt(
+            "morning", "sunny", action_choices=pre_numbered_actions
+        )
+        
+        # Verify both prompts contain numbered actions
+        self.assertIn("Options:", routine_prompt)
+        self.assertIn("1. Work", routine_prompt)
+        self.assertIn("2. Eat", routine_prompt)
+        self.assertIn("3. Sleep", routine_prompt)
+        
+        self.assertIn("Available actions:", decision_prompt)
+        self.assertIn("1. Work", decision_prompt)
+        self.assertIn("2. Eat", decision_prompt)
+        self.assertIn("3. Sleep", decision_prompt)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tiny_prompt_builder.py
+++ b/tests/test_tiny_prompt_builder.py
@@ -220,11 +220,25 @@ class TestPromptBuilder(unittest.TestCase):
         self.assertEqual(self.prompt_builder.needs_priorities, {"need1": 1})
 
     def test_generate_daily_routine_prompt(self):
-        self.mock_actions.prioritize_actions.return_value = ["buy_food", "social_visit"]
-        with patch('tiny_prompt_builder.descriptors.get_action_descriptors') as mock_desc:
-            mock_desc.side_effect = ["Go shopping", "Meet friend"]
-            prompt = self.prompt_builder.generate_daily_routine_prompt("morning", "sunny")
-        self.mock_actions.prioritize_actions.assert_called_once_with(self.character)
+        # Mock context_manager to avoid dependency issues and ensure stable character info
+        self.prompt_builder.context_manager = MagicMock()
+        self.prompt_builder.context_manager.assemble_complete_context.return_value = {
+            'character': {'basic_info': {'name': 'Emily', 'job': 'Engineer'}},
+            'memories': [],
+            'goals': {'active_goals': [], 'needs_priorities': {}}
+        }
+        # Patch ActionOptions to avoid instantiation issues with MockCharacter
+        with patch('tiny_prompt_builder.ActionOptions') as MockActionOptions:
+            mock_instance = MagicMock()
+            mock_instance.prioritize_actions.return_value = ["buy_food", "social_visit"]
+            MockActionOptions.return_value = mock_instance
+            
+            with patch('tiny_prompt_builder.descriptors.get_action_descriptors') as mock_desc:
+                mock_desc.side_effect = ["Go shopping", "Meet friend"]
+                prompt = self.prompt_builder.generate_daily_routine_prompt("morning", "sunny")
+            
+            mock_instance.prioritize_actions.assert_called_once_with(self.character)
+        
         self.assertIn("1. Go shopping to Buy_Food.", prompt)
         self.assertIn("2. Meet friend to Social_Visit.", prompt)
         self.assertIn("Emily, I choose", prompt)
@@ -417,6 +431,141 @@ class TestDynamicActionGeneration(unittest.TestCase):
                 
                 # Verify prompt contains fallback action
                 self.assertIn("Test Action", prompt)
+
+
+class TestGenerateDailyRoutinePromptWithActions(unittest.TestCase):
+    """Test suite for generate_daily_routine_prompt with actions parameter functionality."""
+    
+    def setUp(self):
+        """Set up test cases for actions parameter testing."""
+        self.character = MockCharacter(hunger_level=5, wealth_money=20)
+        self.prompt_builder = PromptBuilder(self.character)
+        
+        # Mock dependencies
+        self.mock_context_manager = MagicMock()
+        self.prompt_builder.context_manager = self.mock_context_manager
+        
+        # Set up default context
+        self.mock_context_manager.assemble_complete_context.return_value = {
+            'character': {
+                'basic_info': {
+                    'name': 'Emily',
+                    'job': 'Engineer'
+                }
+            },
+            'memories': [],
+            'goals': {
+                'active_goals': [],
+                'needs_priorities': {}
+            }
+        }
+        
+    def test_actions_parameter_none_uses_prioritize_actions(self):
+        """Test that when actions=None, the function calls prioritize_actions."""
+        # Set up mock to return specific actions
+        expected_actions = ['work', 'eat', 'sleep', 'exercise']
+        
+        # Patch ActionOptions at the module level to avoid instantiation issues
+        with patch('tiny_prompt_builder.ActionOptions') as MockActionOptions:
+            mock_instance = MagicMock()
+            mock_instance.prioritize_actions.return_value = expected_actions
+            MockActionOptions.return_value = mock_instance
+            
+            with patch('tiny_prompt_builder.descriptors.get_action_descriptors') as mock_desc:
+                mock_desc.side_effect = lambda x: x.replace('_', ' ').title()
+                prompt = self.prompt_builder.generate_daily_routine_prompt(
+                    "morning", "sunny", actions=None
+                )
+            
+            # Verify ActionOptions was instantiated and prioritize_actions was called
+            MockActionOptions.assert_called_once()
+            mock_instance.prioritize_actions.assert_called_once_with(self.character)
+        
+        # Verify actions appear in prompt
+        self.assertIn("Options:", prompt)
+        
+    def test_actions_parameter_provided_skips_prioritize_actions(self):
+        """Test that when actions are provided, prioritize_actions is not called."""
+        custom_actions = ['read_book', 'write_code', 'debug']
+        
+        # Patch ActionOptions to verify it's NOT instantiated when actions are provided
+        with patch('tiny_prompt_builder.ActionOptions') as MockActionOptions:
+            with patch('tiny_prompt_builder.descriptors.get_action_descriptors') as mock_desc:
+                mock_desc.side_effect = lambda x: x.replace('_', ' ').title()
+                prompt = self.prompt_builder.generate_daily_routine_prompt(
+                    "morning", "sunny", actions=custom_actions
+                )
+            
+            # Verify ActionOptions was NOT instantiated when actions are provided
+            MockActionOptions.assert_not_called()
+        
+        # Verify custom actions appear in prompt
+        self.assertIn("Options:", prompt)
+        
+    def test_actions_formatted_with_numbers_during_iteration(self):
+        """Test that actions are numbered during iteration (1. 2. 3. etc)."""
+        unnumbered_actions = ['action_one', 'action_two', 'action_three']
+        
+        with patch('tiny_prompt_builder.descriptors.get_action_descriptors') as mock_desc:
+            mock_desc.side_effect = lambda x: x.replace('_', ' ').title()
+            prompt = self.prompt_builder.generate_daily_routine_prompt(
+                "morning", "sunny", actions=unnumbered_actions
+            )
+        
+        # Verify actions are numbered in the prompt
+        self.assertIn("1. Action One", prompt)
+        self.assertIn("2. Action Two", prompt)
+        self.assertIn("3. Action Three", prompt)
+        
+    def test_actions_not_prenumbered(self):
+        """Test that the function expects unnumbered actions (not pre-numbered strings)."""
+        # This tests the fix - actions should NOT be pre-numbered
+        unnumbered_actions = ['work', 'eat', 'sleep']
+        
+        with patch('tiny_prompt_builder.descriptors.get_action_descriptors') as mock_desc:
+            mock_desc.side_effect = lambda x: x.replace('_', ' ').title()
+            prompt = self.prompt_builder.generate_daily_routine_prompt(
+                "morning", "sunny", actions=unnumbered_actions
+            )
+        
+        # Should NOT find double-numbering like "1. 1. Work"
+        self.assertNotIn("1. 1.", prompt)
+        self.assertNotIn("2. 2.", prompt)
+        
+        # Should find proper single numbering
+        self.assertIn("1. Work", prompt)
+        self.assertIn("2. Eat", prompt)
+        self.assertIn("3. Sleep", prompt)
+        
+    def test_consistency_with_decision_prompt_pattern(self):
+        """Test that action handling is consistent with generate_decision_prompt pattern."""
+        # Both functions should handle actions consistently - daily_routine numbers them,
+        # decision_prompt expects pre-numbered strings
+        test_actions = ['work', 'eat', 'sleep']
+        
+        with patch('tiny_prompt_builder.descriptors.get_action_descriptors') as mock_desc:
+            mock_desc.side_effect = lambda x: x.replace('_', ' ').title()
+            
+            # Generate daily routine prompt with unnumbered actions
+            routine_prompt = self.prompt_builder.generate_daily_routine_prompt(
+                "morning", "sunny", actions=test_actions
+            )
+            
+            # Verify routine prompt has numbered actions (it adds numbering)
+            self.assertIn("1. Work", routine_prompt)
+            self.assertIn("2. Eat", routine_prompt)
+            self.assertIn("3. Sleep", routine_prompt)
+            
+            # Generate decision prompt with pre-numbered actions (as used by StrategyManager)
+            pre_numbered_actions = ['1. Work', '2. Eat', '3. Sleep']
+            decision_prompt = self.prompt_builder.generate_decision_prompt(
+                "morning", "sunny", action_choices=pre_numbered_actions
+            )
+            
+            # Verify decision prompt contains the pre-numbered actions as-is
+            self.assertIn("1. Work", decision_prompt)
+            self.assertIn("2. Eat", decision_prompt)
+            self.assertIn("3. Sleep", decision_prompt)
 
 
 if __name__ == "__main__":

--- a/tiny_prompt_builder.py
+++ b/tiny_prompt_builder.py
@@ -2591,24 +2591,17 @@ class PromptBuilder:
         prompt += f"{self.character.name}, it's {time}, and {descriptors.get_weather_description(weather)}. You're feeling {descriptors.get_feeling_health(self.character.health_status)}, and {descriptors.get_feeling_hunger(self.character.hunger_level)}. "
         prompt += f"{descriptors.get_event_recent(self.character.recent_event)}, and {descriptors.get_financial_situation(self.character.wealth_money)}. {descriptors.get_motivation()} {getattr(self.character, 'long_term_goal', 'personal growth')}. {descriptors.get_routine_question_framing()}"
         
-        # Generate dynamic action choices from StrategyManager/GOAPPlanner
+        # Generate action choices
         prompt += "Options:\n"
-        dynamic_action_choices = self.prioritize_actions()
         
-        if dynamic_action_choices:
-            # Use dynamically generated action choices with utility scores
-            for choice in dynamic_action_choices:
-                prompt += f"{choice}\n"
-        else:
-            # Fallback to basic action prioritization if StrategyManager unavailable
-            actions = self.action_options.prioritize_actions(self.character)
-            for i, action in enumerate(actions[:5], 1):
-                try:
-                    descriptor = descriptors.get_action_descriptors(action)
-                except (KeyError, AttributeError):
-                    descriptor = action.replace("_", " ").title()
-                action_name = action.replace("_", " ").title().replace(" ", "_")
-                prompt += f"{i}. {descriptor} to {action_name}.\n"
+        # Use the actions parameter (either provided by caller or prioritized above)
+        for i, action in enumerate(actions, 1):
+            try:
+                descriptor = descriptors.get_action_descriptors(action)
+            except (KeyError, AttributeError):
+                descriptor = action.replace("_", " ").title()
+            action_name = action.replace("_", " ").title().replace(" ", "_")
+            prompt += f"{i}. {descriptor} to {action_name}.\n"
         # Add structured output format instructions
         if output_format == "json":
             prompt += f"\n\n{OutputSchema.get_decision_schema()}"
@@ -2773,7 +2766,7 @@ class PromptBuilder:
 
         # Enhanced action choices with better formatting
         prompt += f"\nAvailable actions:\n"
-        for i, action_choice in enumerate(action_choices):
+        for action_choice in action_choices:
             prompt += f"{action_choice}\n"
 
         prompt += f"\nChoose the action that best addresses your ACTIVE GOALS and PRESSING NEEDS listed above. "


### PR DESCRIPTION
## Description
- update `generate_daily_routine_prompt` to use prioritized actions
- allow passing in an action list and format like `generate_decision_prompt`

## Technical Implementation
- call `ActionOptions.prioritize_actions` when no list is provided
- format actions as numbered strings similar to the decision prompt

## Related Issues
Closes #None

## Testing
- `python -m unittest discover tests` *(fails: ImportError: Start directory is not importable)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_687b16d5eee88327bc43ddb3a4f80a68)